### PR TITLE
updated highlights to include tables and values

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,27 +1,41 @@
-(pair
-  key: (_) @string.special.key)
-
-(string) @string
-
-(filesize unit: _ @variable.parameter)
-(duration unit: _ @variable.parameter)
-
-(table
-  head:(_) @constant)
-
-(number) @number
-(date) @constant
 [
-  (null)
   (true)
   (false)
-] @constant.builtin
+] @boolean
 
-(escape_sequence) @escape
+(null) @constant.builtin
+
+(number) @number
+
+(pair
+  key: (string) @property)
+
+(pair
+  value: (string) @string)
+
+(table_values
+  (string) @string)
+
+(table_header
+  (identifier) @property)
+
 [
-    ","
-    ";"
+  ","
+  ":"
 ] @punctuation.delimiter
-[":"] @punctuation.special
 
-(comment) @comment
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+("\"" @conceal
+  (#set! conceal ""))
+
+(escape_sequence) @string.escape
+
+((escape_sequence) @conceal
+  (#eq? @conceal "\\\"")
+  (#set! conceal "\""))

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -3,25 +3,25 @@
   (false)
 ] @boolean
 
+(string) @string
+
+(comment) @comment
+
 (null) @constant.builtin
 
 (number) @number
 
-(pair
-  key: (string) @property)
-
-(pair
-  value: (string) @string)
-
-(table_values
-  (string) @string)
 
 (table_header
   (identifier) @property)
 
+(date) @string.special
+(filesize_unit) @string.special.symbol
+
 [
   ","
   ":"
+  ";"
 ] @punctuation.delimiter
 
 [

--- a/test/highlight/basic.nuon
+++ b/test/highlight/basic.nuon
@@ -1,0 +1,53 @@
+# Test booleans and null values
+true
+# <- boolean
+false
+# <- boolean
+null
+# <- constant.builtin
+
+# Test numbers
+42
+# <- number
+-17
+# <- number
+3.14159
+# <- number
+
+# Test strings and identifiers
+"hello world"
+# <- conceal
+# ^ string
+#           ^ conceal
+unquoted_string
+# <- string
+
+# Test record with key-value pairs
+{
+# <- punctuation.bracket
+  "name": "value",
+  #^ string
+  #     ^ punctuation.delimiter
+  #        ^ string
+  #              ^ punctuation.delimiter
+  "count": 42,
+  #^ string
+  #      ^ punctuation.delimiter
+  #        ^ number
+  #          ^ punctuation.delimiter
+  "active": true
+  #^ string
+  #       ^ punctuation.delimiter
+  #         ^ boolean
+}
+# <- punctuation.bracket
+
+# Test array
+[1, 2, 3]
+# <- punctuation.bracket
+#^ number
+# ^ punctuation.delimiter
+#   ^ number
+#    ^ punctuation.delimiter
+#      ^ number
+#       ^ punctuation.bracket

--- a/test/highlight/table.nuon
+++ b/test/highlight/table.nuon
@@ -1,0 +1,27 @@
+# Test table structure with various data types
+[
+# <- punctuation.bracket
+[name, type, size, modified];
+# <- punctuation.bracket
+#^ property
+#    ^ punctuation.delimiter
+#      ^ property
+#        ^ property
+#          ^ punctuation.delimiter
+#            ^ property
+#                ^ punctuation.delimiter
+#                  ^ property
+#                          ^ punctuation.bracket
+#                           ^ punctuation.delimiter
+[.editorconfig, file, 502b, 2024-05-29T01:55:16+02:00],
+# <- punctuation.bracket
+#^ string
+#             ^ punctuation.delimiter
+#               ^ string
+#                   ^ punctuation.delimiter
+#                     ^ number
+#                        ^ string.special.symbol
+#                         ^ punctuation.delimiter
+#                           ^ string.special
+]
+# <- punctuation.bracket

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -10,7 +10,8 @@
         "nuon"
       ],
       "injection-regex": "^nuon$",
-      "class-name": "TreeSitterNuon"
+      "class-name": "TreeSitterNuon",
+      "highlights": "queries/highlights.scm"
     }
   ],
   "metadata": {


### PR DESCRIPTION
Based off of https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/json/highlights.scm 

with additional handling for `table_header` and `array` -> `table_values`